### PR TITLE
resolve duplicate option name 'h'fix(command): resolve duplicate option name 'h'

### DIFF
--- a/src/Stat.ts
+++ b/src/Stat.ts
@@ -53,7 +53,7 @@ export class Stat {
         .usage('查询命令统计，可指定查询范围，默认当前群组。')
         .option('user', '-u <user:string> 指定用户')
         .option('guild', '-g <guildId:string> 指定群组')
-        .option('separate', '-h 分离展示')
+        .option('separate', '-s 分离展示')
         .option('all', '-a 全局')
         .action(createHandler(async (scope, options) => {
           const stats = await this.ctx.database.select('analyse_cmd').where({ uid: { $in: scope.uids } }).groupBy('command', { count: row => $.sum(row.count), lastUsed: row => $.max(row.timestamp) }).orderBy('count', 'desc').execute();
@@ -117,7 +117,7 @@ export class Stat {
         .usage('查询发言排行，可指定查询范围，默认当前群组。')
         .option('guild', '-g <guildId:string> 指定群组')
         .option('type', '-t <type:string> 指定类型')
-        .option('hours', '-h <hours:number> 指定时长', { fallback: 24 })
+        .option('hours', '-H <hours:number> 指定时长', { fallback: 24 })
         .option('all', '-a 全局')
         .action(createHandler(async (scope, options) => {
           const { hours, type } = options;
@@ -144,7 +144,7 @@ export class Stat {
         .usage('查询活跃统计，可指定查询范围，默认当前群组。')
         .option('user', '-u <user:string> 指定用户')
         .option('guild', '-g <guildId:string> 指定群组')
-        .option('hours', '-h <hours:number> 指定偏移时长')
+        .option('hours', '-O <hours:number> 指定偏移时长')
         .option('all', '-a 全局')
         .option('days', '-d 切换至天数')
         .action(createHandler(async (scope, options) => {


### PR DESCRIPTION
在 cmdstat 子命令中，将 .option('separate', '-h 分离展示') 修改为 .option('separate', '-s 分离展示')。
在 rankstat 子命令中，将 .option('hours', '-h <hours:number> 指定时长', { fallback: 24 }) 修改为 .option('hours', '-H <hours:number> 指定时长', { fallback: 24 })。
在 activity 子命令中，将 .option('hours', '-h <hours:number> 指定偏移时长') 修改为 .option('hours', '-O <hours:number> 指定偏移时长')。