### PR TITLE
Update Stat.ts

### DIFF
--- a/src/Stat.ts
+++ b/src/Stat.ts
@@ -53,7 +53,7 @@ export class Stat {
         .usage('查询命令统计，可指定查询范围，默认当前群组。')
         .option('user', '-u <user:string> 指定用户')
         .option('guild', '-g <guildId:string> 指定群组')
-        .option('separate', '-h 分离展示')
+        .option('separate', '-s 分离展示')
         .option('all', '-a 全局')
         .action(createHandler(async (scope, options) => {
           const stats = await this.ctx.database.select('analyse_cmd').where({ uid: { $in: scope.uids } }).groupBy('command', { count: row => $.sum(row.count), lastUsed: row => $.max(row.timestamp) }).orderBy('count', 'desc').execute();
@@ -117,7 +117,7 @@ export class Stat {
         .usage('查询发言排行，可指定查询范围，默认当前群组。')
         .option('guild', '-g <guildId:string> 指定群组')
         .option('type', '-t <type:string> 指定类型')
-        .option('hours', '-h <hours:number> 指定时长', { fallback: 24 })
+        .option('hours', '-w <hours:number> 指定时长', { fallback: 24 })
         .option('all', '-a 全局')
         .action(createHandler(async (scope, options) => {
           const { hours, type } = options;
@@ -144,7 +144,7 @@ export class Stat {
         .usage('查询活跃统计，可指定查询范围，默认当前群组。')
         .option('user', '-u <user:string> 指定用户')
         .option('guild', '-g <guildId:string> 指定群组')
-        .option('hours', '-h <hours:number> 指定偏移时长')
+        .option('hours', '-o <hours:number> 指定偏移时长')
         .option('all', '-a 全局')
         .option('days', '-d 切换至天数')
         .action(createHandler(async (scope, options) => {


### PR DESCRIPTION
解决参数-h冲突问题：

```
2025-08-12 16:36:56 [E] app Error: duplicate option name "h" for command "cmdstat"
                            at _Command._assignOption (/koishi/node_modules/@koishijs/core/lib/index.cjs:347:17)
                            at _Command._createOption (/koishi/node_modules/@koishijs/core/lib/index.cjs:338:12)
                            at _Command.option (/koishi/node_modules/@koishijs/core/lib/index.cjs:1032:10)
                            at Stat.registerCommands (/koishi/node_modules/koishi-plugin-chat-analyse/lib/index.js:555:157)
                            at Object.apply (/koishi/node_modules/koishi-plugin-chat-analyse/lib/index.js:1017:25)
                            at MainScope.apply (/koishi/node_modules/@cordisjs/core/lib/index.cjs:876:26)
                            at /koishi/node_modules/@cordisjs/core/lib/index.cjs:900:49
                            at MainScope.ensure (/koishi/node_modules/@cordisjs/core/lib/index.cjs:686:18)
                            at MainScope.start (/koishi/node_modules/@cordisjs/core/lib/index.cjs:900:12)
                            at MainScope.init (/koishi/node_modules/@cordisjs/core/lib/index.cjs:719:12)
```